### PR TITLE
讓他可以兼容python2跟3

### DIFF
--- a/demos/pig_latin.py
+++ b/demos/pig_latin.py
@@ -27,7 +27,7 @@ END_SYMBOL = '$'
 CHAR_SET = set(string.ascii_lowercase + BEGIN_SYMBOL + END_SYMBOL)
 CHAR_NUM = len(CHAR_SET)
 CHAR_TO_INDICES = {c:i for i, c in enumerate(CHAR_SET)}
-INDICES_TO_CHAR = {i:c for c, i in CHAR_TO_INDICES.iteritems()}
+INDICES_TO_CHAR = {i:c for c, i in CHAR_TO_INDICES.items()}
 MAX_INPUT_LEN = 18
 MAX_OUTPUT_LEN = 20
 


### PR DESCRIPTION
您好，感謝您Seq2seq的教學 讓小弟受益涼多
不過python3的iteritems已經移除  改成回傳generator的型式
如果改用`items()`的話，就能兼容python2跟3版
希望有幫上忙